### PR TITLE
Add rake-compiler to development dependency

### DIFF
--- a/mikunyan.gemspec
+++ b/mikunyan.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'oily_png', '~> 1'
   spec.add_development_dependency 'pry', '~> 0'
+  spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'usamin', '~> 7'
 end


### PR DESCRIPTION
This gem is required for `rake build` task.

Without this, user will get this cryptic error message:

```
$ rake build
rake aborted!
LoadError: cannot load such file -- rake/extensiontask
```